### PR TITLE
Add Insert example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,13 @@ Youtube.channels.list({
 // Add a Video to a playlist
 Youtube.playlistItems.insert({
     "part": "snippet"
-  , "resource" : {
-  		"playlistId": "youtube playlist id"
-  		, "resourceId": {
-  	  		"videoId": "youtube video id"
-  	  		, "kind": "youtube#video"
-  		}
-  	}
-}, function (err, data) {
-    console.log(err || data);
+  , "resource": {
+      "playlistId": "YouTube Playlist ID"
+    , "resourceId": {
+       "videoId": "YouTube Video ID"
+     , "kind": "youtube#video"
+      }
+    }
 });
 ```
 


### PR DESCRIPTION
The Google API client expects a well-formed JSON object as the `resource` parameter in order to set the body of an API request. It took me a while to figure this out - might be helpful to others.
