### PR TITLE
Enabled passing client ID, client secret, and redirect URL to the auth call

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,22 @@ Youtube.playlistItems.insert({
 
 ## Authentication
 
-### OAuth
+### OAuth (Access Token)
 ```JS
 Youtube.authenticate({
     type: "oauth"
   , token: "your access token"
+});
+```
+
+### OAuth (Refresh Token)
+```JS
+Youtube.authenticate({
+    type: "oauth"
+  , refresh_token: "your refresh token"
+  , client_id: "your client id"
+  , client_secret: "your client secret"
+  , redirect_url: "your refresh url"
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var Client = module.exports = function(config) {};
         var authObj = null;
         switch (options.type) {
             case "oauth":
-                authObj = new  Google.auth.OAuth2();
+                authObj = new Google.auth.OAuth2(options.client_id, options.client_secret, options.redirect_url);
                 authObj.setCredentials({
                     access_token: options.access_token || options.token
                   , refresh_token: options.refresh_token

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     {
       "name": "Vels (velsa)",
       "email": "velshome@yahoo.com"
+    },
+    {
+      "name": "Rasmus Karlsson",
+      "email": "pajlada@bithack.se"
     }
   ],
   "repository": {


### PR DESCRIPTION
That way, it's possible to only send a refresh_token, and the OAuth2 object will take care of refreshing the access_token for us.