### PR TITLE
Upload example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,38 +31,88 @@ You may be interested to download [this test application](https://github.com/Ion
 and play with the YouTube API resources there. Below you see an example how to use the library.
 
 ```js
-// Dependencies
-var Youtube = require("youtube-api");
+/**
+ * This script uploads a video (specifically `video.mp4` from the current
+ * directory) to YouTube,
+ *
+ * To run this script you have to create OAuth2 credentials and download them
+ * as JSON and replace the `credentials.json` file. Then install the
+ * dependencies:
+ *
+ * npm i r-json lien opn bug-killer
+ *
+ * Don't forget to run an `npm i` to install the `youtube-api` dependencies.
+ * */
 
-// Authenticate using an access token
-Youtube.authenticate({
+// Depende3ncies
+var Youtube = require("youtube-api")
+  , Fs = require("fs")
+  , ReadJson = require("r-json")
+  , Lien = require("lien")
+  , Logger = require("bug-killer")
+  , Opn = require("opn")
+  ;
+
+// Constants
+// I downloaded the file from OAuth2 -> Download JSON
+const CREDENTIALS = ReadJson("./credentials.json");
+
+// Init lien server
+var server = new Lien({
+    host: "localhost"
+  , port: 5000
+});
+
+var stdIn = ReadLine.createInterface({
+    input: process.stdin
+  , output: process.stdout
+});
+
+// Authenticate
+// You can access the Youtube resources via OAuth2 only.
+// https://developers.google.com/youtube/v3/guides/moving_to_oauth#service_accounts
+var oauth = Youtube.authenticate({
     type: "oauth"
-  , token: "your access token"
+  , client_id: CREDENTIALS.web.client_id
+  , client_secret: CREDENTIALS.web.client_secret
+  , redirect_url: CREDENTIALS.web.redirect_uris[0]
 });
 
-// List your subcribers
-Youtube.subscriptions.list({
-    "part": "id"
-  , "mySubscribers": true
-  , "maxResults": 50
-}, function (err, data) {
-    console.log(err || data);
-});
+Opn(oauth.generateAuthUrl({
+    access_type: "offline"
+  , scope: ["https://www.googleapis.com/auth/youtube.upload"]
+}));
 
-// Add a Video to a playlist
-Youtube.playlistItems.insert({
-    "part": "snippet"
-  , "resource": {
-        "snippet": {
-            "playlistId": "YouTube Playlist ID"
-          , "resourceId": {
-                "kind" : "youtube#video"
-              , "videoId" : "YouTube Video ID"
+// Handle oauth2 callback
+server.page.add("/oauth2callback", function (lien) {
+    Logger.log("Trying to get the token using the following code: " + lien.search.code);
+    oauth.getToken(lien.search.code, function(err, tokens) {
+        if (err) { lien(err, 400); return Logger.log(err); }
+        oauth.setCredentials(tokens);
+        Youtube.videos.insert({
+            resource: {
+                // Video title and description
+                snippet: {
+                    title: "Testing YoutTube API NodeJS module"
+                  , description: "Test video upload via YouTube API"
+                }
+                // I don't want to spam my subscribers
+              , status: {
+                    privacyStatus: "private"
+                }
             }
-        }
-    }
-}, function (err, data) {
-    console.log(err || data);
+            // This is for the callback function
+          , part: "snippet,status"
+
+            // Create the readable stream to upload the video
+          , media: {
+                body: Fs.createReadStream("video.mp4")
+            }
+        }, function (err, data) {
+            if (err) { return lien.end(err, 400); }
+            lien.end(data);
+        });
+    });
 });
 
 ```

--- a/example/credentials.json
+++ b/example/credentials.json
@@ -1,0 +1,13 @@
+{
+    "web": {
+        "client_id": "103..................................hf7bb75o0.apps.googleusercontent.com",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://accounts.google.com/o/oauth2/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_email": "1038................................dhf7bb75o0@developer.gserviceaccount.com",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/1038...................................7bb75o0%40developer.gserviceaccount.com",
+        "client_secret": "ji.....................w",
+        "redirect_uris": ["http://localhost:5000/oauth2callback"],
+        "javascript_origins": ["http://localhost:5000"]
+    }
+}

--- a/example/index.js
+++ b/example/index.js
@@ -1,33 +1,84 @@
-// Dependencies
-var Youtube = require("../lib");
+/**
+ * This script uploads a video (specifically `video.mp4` from the current
+ * directory) to YouTube,
+ *
+ * To run this script you have to create OAuth2 credentials and download them
+ * as JSON and replace the `credentials.json` file. Then install the
+ * dependencies:
+ *
+ * npm i r-json lien opn bug-killer
+ *
+ * Don't forget to run an `npm i` to install the `youtube-api` dependencies.
+ * */
 
-// Authenticate using an access token
-Youtube.authenticate({
+// Depende3ncies
+var Youtube = require("../lib")
+  , Fs = require("fs")
+  , ReadJson = require("r-json")
+  , Lien = require("lien")
+  , Logger = require("bug-killer")
+  , Opn = require("opn")
+  ;
+
+// Constants
+// I downloaded the file from OAuth2 -> Download JSON
+const CREDENTIALS = ReadJson("./credentials.json");
+
+// Init lien server
+var server = new Lien({
+    host: "localhost"
+  , port: 5000
+});
+
+
+var stdIn = ReadLine.createInterface({
+    input: process.stdin
+  , output: process.stdout
+});
+
+// Authenticate
+// You can access the Youtube resources via OAuth2 only.
+// https://developers.google.com/youtube/v3/guides/moving_to_oauth#service_accounts
+var oauth = Youtube.authenticate({
     type: "oauth"
-  , token: "your access token"
+  , client_id: CREDENTIALS.web.client_id
+  , client_secret: CREDENTIALS.web.client_secret
+  , redirect_url: CREDENTIALS.web.redirect_uris[0]
 });
 
-// List your subcribers
-Youtube.subscriptions.list({
-    "part": "id"
-  , "mySubscribers": true
-  , "maxResults": 50
-}, function (err, data) {
-    console.log(err || data);
-});
+Opn(oauth.generateAuthUrl({
+    access_type: "offline"
+  , scope: ["https://www.googleapis.com/auth/youtube.upload"]
+}));
 
-// Add a Video to a playlist
-Youtube.playlistItems.insert({
-    "part": "snippet"
-  , "resource": {
-        "snippet": {
-            "playlistId": "YouTube Playlist ID"
-          , "resourceId": {
-                "kind" : "youtube#video"
-              , "videoId" : "YouTube Video ID"
+// Handle oauth2 callback
+server.page.add("/oauth2callback", function (lien) {
+    Logger.log("Trying to get the token using the following code: " + lien.search.code);
+    oauth.getToken(lien.search.code, function(err, tokens) {
+        if (err) { lien(err, 400); return Logger.log(err); }
+        oauth.setCredentials(tokens);
+        Youtube.videos.insert({
+            resource: {
+                // Video title and description
+                snippet: {
+                    title: "Testing YoutTube API NodeJS module"
+                  , description: "Test video upload via YouTube API"
+                }
+                // I don't want to spam my subscribers
+              , status: {
+                    privacyStatus: "private"
+                }
             }
-        }
-    }
-}, function (err, data) {
-    console.log(err || data);
+            // This is for the callback function
+          , part: "snippet,status"
+
+            // Create the readable stream to upload the video
+          , media: {
+                body: Fs.createReadStream("video.mp4")
+            }
+        }, function (err, data) {
+            if (err) { return lien.end(err, 400); }
+            lien.end(data);
+        });
+    });
 });


### PR DESCRIPTION
In this pull request I added the upload example, full example.

:warning: [JWT cannot upload videos to YouTube](https://developers.google.com/youtube/v3/guides/moving_to_oauth#service_accounts) :warning: 

> Service accounts do not work for YouTube Data API calls because service accounts require an associated YouTube channel, and you cannot associate new or existing channels with service accounts. If you use a service account to call the YouTube Data API, the API server returns an error with the error type set to `unauthorized` and the reason set to `youtubeSignupRequired`.

So, if you try to use JWT, you will get an error (exactly what @shiffman encountered in #36). The ~~alternative~~ right way is to use OAuth2. That means you have to have a user interaction page and a server (in this example running on `localhost:5000`.

This example expects that you downloaded the JSON credentials from your Google app (where you set the url to `http://localhost:5000`) and you have the `video.mp4` in the example directory.

When you run `node upload` in the example directory, the page to allow app access will be opened in the default browser. Allow access and then be patient: in the background your video is uploaded. After the upload is finished, you will get the result data in browser. :tada: 

/cc @periyasamy25  @shiffman 

This should fix #36 and #35.