### PR TITLE
Update dependency versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 // Dependencies
-var Google = require("googleapis");
+var Google = require("googleapis").google;
 
 // Create YoutTube client
 var Client = module.exports = function(config) {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-api",
-  "version": "2.0.10",
+  "version": "3.0.1",
   "description": "A Node.JS module, which provides an object oriented wrapper for the Youtube v3 API.",
   "main": "lib/index.js",
   "author": "Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/IonicaBizau/youtube-api/issues"
   },
   "dependencies": {
-    "googleapis": "^5.2.1"
+    "googleapis": "^47.0.0"
   },
   "homepage": "https://github.com/IonicaBizau/youtube-api",
   "directories": {
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "bug-killer": "^4.2.2",
-    "lien": "^1.0.1",
+    "lien": "^3.3.0",
     "opn": "^4.0.1",
     "pretty-bytes": "^3.0.1",
     "r-json": "^1.2.2"


### PR DESCRIPTION
Relevant issue: #88

This PR updates the dependencies for the package to the latest version to fix some security issues.

It's tagged as `3.0.1` because, unfortunately, this commit is not drop-in compatible with the previous version (`googleapis` has changed a lot in the past few years); however, the changes are minimal.

For example, I tested this update with `youtube-playlist-info`, and in a callback, instead of using `data`, you have to change it to `data.data` (see https://github.com/ohnx/youtube-playlist-info/commit/06c70748a9d156daab807a50b3ed5738532cbf3a for the changes needed).